### PR TITLE
ci(security): harden supply chain security

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# CODEOWNERS
+# リリースワークフローおよびパッケージ設定の変更にはメンテナーの承認が必要
+# @J-Quants/Developpers チームをあらかじめ Organization で作成してください
+
+.github/workflows/ @J-Quants/Developpers
+Cargo.toml         @J-Quants/Developpers
+Cargo.lock         @J-Quants/Developpers
+SECURITY.md        @J-Quants/Developpers

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  - package-ecosystem: cargo
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,6 +120,8 @@ jobs:
     permissions:
       contents: write
       actions: read
+      id-token: write
+      attestations: write
     outputs:
       sha256_x86_64_darwin: ${{ steps.checksums.outputs.sha256_x86_64_darwin }}
       sha256_aarch64_darwin: ${{ steps.checksums.outputs.sha256_aarch64_darwin }}
@@ -152,7 +154,12 @@ jobs:
           echo "sha256_x86_64_linux=${SHA_X86_LINUX}" >> "$GITHUB_OUTPUT"
           echo "sha256_aarch64_linux=${SHA_ARM_LINUX}" >> "$GITHUB_OUTPUT"
 
-          sha256sum * > checksums.txt
+          sha256sum *.tar.gz *.zip > checksums.txt
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@e8998f949152b193b063cb0ec769d69d929409be # v2.4.0
+        with:
+          subject-path: "artifacts/*.tar.gz,artifacts/*.zip"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2.6.1
@@ -165,15 +172,25 @@ jobs:
     name: Update Homebrew Formula
     needs: release
     runs-on: ubuntu-latest
+    environment: release
     permissions:
       contents: read
 
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547 # v1.12.0
+        with:
+          app-id: ${{ secrets.TAP_APP_ID }}
+          private-key: ${{ secrets.TAP_APP_PRIVATE_KEY }}
+          owner: J-Quants
+          repositories: homebrew-tap
+
       - name: Checkout homebrew-tap
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           repository: J-Quants/homebrew-tap
-          token: ${{ secrets.TAP_GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: homebrew-tap
 
       - name: Update formula
@@ -226,13 +243,24 @@ jobs:
           end
           RUBY
 
-      - name: Commit and push formula
-        run: |
-          TAG="${GITHUB_REF_NAME}"
-          VERSION="${TAG#v}"
-          cd homebrew-tap
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add Formula/jquants.rb
-          git diff --cached --quiet || git commit -m "chore: update jquants to v${VERSION}"
-          git push
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@22a9089034f40e5a961c8808d113e2c98fb63676 # v7.0.11
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          path: homebrew-tap
+          branch: update/jquants-${{ github.ref_name }}
+          title: "chore: update jquants to ${{ github.ref_name }}"
+          body: |
+            Automated formula update for jquants ${{ github.ref_name }}
+
+            Release: https://github.com/J-Quants/jquants-cli/releases/tag/${{ github.ref_name }}
+
+            SHA256 checksums:
+            - `x86_64-apple-darwin`: `${{ needs.release.outputs.sha256_x86_64_darwin }}`
+            - `aarch64-apple-darwin`: `${{ needs.release.outputs.sha256_aarch64_darwin }}`
+            - `x86_64-unknown-linux-musl`: `${{ needs.release.outputs.sha256_x86_64_linux }}`
+            - `aarch64-unknown-linux-musl`: `${{ needs.release.outputs.sha256_aarch64_linux }}`
+          labels: automated
+          commit-message: "chore: update jquants to ${{ github.ref_name }}"
+          committer: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"
+          author: "github-actions[bot] <github-actions[bot]@users.noreply.github.com>"

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## サポートバージョン
+
+| バージョン | サポート状態 |
+| ---------- | ------------ |
+| 最新リリース | サポート中 |
+| それ以前 | サポート外 |
+
+## 脆弱性の報告
+
+セキュリティ上の問題を発見した場合は、**公開 Issue には投稿しないでください**。
+
+### 報告方法
+
+GitHub の **Private vulnerability reporting** を使用してください:
+
+1. [Security タブ](https://github.com/J-Quants/jquants-cli/security) を開く
+2. "Report a vulnerability" をクリック
+3. 詳細を記入して送信
+
+### 報告内容
+
+報告時に以下の情報をご提供ください:
+
+- 脆弱性の種類と影響範囲
+- 再現手順
+- 影響を受けるバージョン
+- 可能であれば、修正案や回避策
+
+### 対応フロー
+
+1. 報告受領後、3営業日以内に確認の連絡をします
+2. 調査・修正後、修正バージョンをリリースします
+3. リリース後、[GitHub Security Advisories](https://github.com/J-Quants/jquants-cli/security/advisories) で詳細を公開します
+
+## ビルドの完全性検証
+
+リリースバイナリは [SLSA](https://slsa.dev/) provenance attestation により、GitHub Actions 上でビルドされたことを暗号学的に証明しています。
+
+```sh
+gh attestation verify <downloaded-binary> --repo J-Quants/jquants-cli
+```


### PR DESCRIPTION
## Summary

サプライチェーン攻撃への対策としてセキュリティインフラを強化する。

- **SECURITY.md** — 脆弱性報告ポリシー（GitHub Private Vulnerability Reporting）と SLSA provenance 検証手順を追加
- **Dependabot** — Cargo・GitHub Actions の依存関係を週次で自動更新
- **CODEOWNERS** — `.github/workflows/`, `Cargo.toml`, `Cargo.lock`, `SECURITY.md` の変更にメンテナー承認を必須化
- **SLSA provenance** — リリースバイナリに `actions/attest-build-provenance` による署名を付与（`id-token: write` / `attestations: write` 権限追加）
- **GitHub App トークン移行** — homebrew-tap 更新を PAT から短命 GitHub App トークン（`actions/create-github-app-token`）に切替え
- **PR ベース tap 更新** — `git push` 直接コミットを廃止し `peter-evans/create-pull-request` による PR 作成フローに移行
- **checksums.txt 修正** — `sha256sum *` が自身を含む問題を `sha256sum *.tar.gz *.zip` に修正

## Test Plan

- [ ] リリースワークフローの YAML 構文確認（`actionlint` 等）
- [ ] テストタグ `v0.0.x-rc.1` で release ワークフローを実行し、attestation と homebrew-tap PR が生成されることを確認
- [ ] `gh attestation verify <binary> --repo J-Quants/jquants-cli` で provenance を検証
