### PR TITLE
fix(docs): shell complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,15 @@ jquants logout
 mkdir -p ~/.config/bash/completions
 jquants completion bash > ~/.config/bash/completions/jquants.bash
 source ~/.config/bash/completions/jquants.bash
-# ~/.bashrc に追記
+# ~/.bashrc に追記して永続化
 echo "source ~/.config/bash/completions/jquants.bash" >> ~/.bashrc
 
 # zsh
 mkdir -p ~/.zfunc
 jquants completion zsh > ~/.zfunc/_jquants
-# ~/.zshrc に追記
-fpath=(~/.zfunc $fpath)
-autoload -Uz compinit && compinit
+# ~/.zshrc に追記して永続化
+echo "fpath=(~/.zfunc $fpath)" >> ~/.zshrc
+echo "autoload -Uz compinit && compinit" >> ~/.zshrc
 
 # fish
 mkdir -p ~/.config/fish/completions

--- a/README.md
+++ b/README.md
@@ -95,15 +95,24 @@ jquants logout
 
 ```sh
 # bash
+mkdir -p ~/.config/bash/completions
 jquants completion bash > ~/.config/bash/completions/jquants.bash
+source ~/.config/bash/completions/jquants.bash
+# ~/.bashrc に追記
+echo "source ~/.config/bash/completions/jquants.bash" >> ~/.bashrc
+
 
 # zsh
+mkdir -p ~/.zfunc
 jquants completion zsh > ~/.zfunc/_jquants
+# ~/.zshrc に追記
 fpath=(~/.zfunc $fpath)
 autoload -Uz compinit && compinit
 
 # fish
+mkdir -p ~/.config/fish/completions
 jquants completion fish > ~/.config/fish/completions/jquants.fish
+source ~/.config/fish/completions/jquants.fish
 ```
 
 ## AI Agent 連携

--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ jquants logout
 # bash
 mkdir -p ~/.config/bash/completions
 jquants completion bash > ~/.config/bash/completions/jquants.bash
+# 実行シェルで補完を有効化
 source ~/.config/bash/completions/jquants.bash
 # ~/.bashrc に追記して永続化
 echo "source ~/.config/bash/completions/jquants.bash" >> ~/.bashrc
@@ -104,13 +105,18 @@ echo "source ~/.config/bash/completions/jquants.bash" >> ~/.bashrc
 # zsh
 mkdir -p ~/.zfunc
 jquants completion zsh > ~/.zfunc/_jquants
-# ~/.zshrc に追記して永続化
+# 実行シェルで補完を有効化
+fpath=(~/.zfunc $fpath)
+autoload -Uz compinit && compinit
+# ~/.zshrc に追記して永続化 (すでに同様の設定がある場合は不要)
 echo "fpath=(~/.zfunc $fpath)" >> ~/.zshrc
 echo "autoload -Uz compinit && compinit" >> ~/.zshrc
 
 # fish
 mkdir -p ~/.config/fish/completions
+# 永続化
 jquants completion fish > ~/.config/fish/completions/jquants.fish
+# 実行シェルで補完を有効化
 source ~/.config/fish/completions/jquants.fish
 ```
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ source ~/.config/bash/completions/jquants.bash
 # ~/.bashrc に追記
 echo "source ~/.config/bash/completions/jquants.bash" >> ~/.bashrc
 
-
 # zsh
 mkdir -p ~/.zfunc
 jquants completion zsh > ~/.zfunc/_jquants


### PR DESCRIPTION
# 背景
こちらに記載あるシェルの補完手順と一致がしていません。また、以下URLの `bash` の補完は `.bashrc` に追記されるため次回シェル起動時にはロードされますが
[J-Quants CLI - J-Quants API Reference](https://jpx-jquants.com/ja/spec/jquants-cli)

現状の `README.md` に記載の手順の場合は `~/.config/bash/completions` 配下は `bash` の場合は自動でロードされないためロードが実行されず `~/.config/bash/completions` 配下に補完用 `bash` スクリプトがあるのみとなります。

## 対応
`zsh` の場合は実行シェルでの補完も有効にされている手順に合わせて残り２つの `bash`, `fish` も実行シェルで読み込むように追加しました。
追加で、標準ではディレクトリ先作られないので事前ディレクトリ作成まで手順に入れてます。
ドキュメントURL先では `PowerShell` もありましたが、私の環境下だと Windows 環境自体が無いため本コミットには入れていません。

よろしくおねがいいたします。