### PR TITLE
feat: 決算発表予定日・EDINET系3コマンドを追加、fins/summary・eq dailyの新項目対応、td listのCSV出力を修正

### DIFF
--- a/.claude/skills/jquants-cli-usage/SKILL.md
+++ b/.claude/skills/jquants-cli-usage/SKILL.md
@@ -7,7 +7,8 @@ description: >
   プランごとの API 利用可否・取得可能データ期間（Free/Light/Standard/Premium）の確認にも対応。
   トリガー: jquants, J-Quants, 株価, 株価データ, 銘柄, 四本値, 分足,
   OHLCV, JPX, 東証, TOPIX, 日経225, 先物, オプション, デリバティブ,
-  空売り, 信用取引, 配当, 財務諸表, 決算, PER, PBR, ROE,
+  空売り, 信用取引, 配当, 財務諸表, 決算, 決算発表予定日, PER, PBR, ROE,
+  EDINET, 大株主, 政策保有株式, 大量保有報告書, 有価証券報告書,
   指数, バルクダウンロード, 日本株, Japanese stock,
   stock price, market data, financial statements,
   プラン, サブスクリプション, subscription, plan, Free, Light, Standard, Premium,
@@ -22,7 +23,7 @@ description: >
 
 jquants コマンドを構築するときは、以下の順序で判断する:
 
-1. **データ種別を決める** — 株式(eq)・市場(mkt)・デリバティブ(deriv)・財務(fins)・指数(idx)
+1. **データ種別を決める** — 株式(eq)・市場(mkt)・デリバティブ(deriv)・EDINET書類(edinet)・財務(fins)・指数(idx)
 2. **プラン制限を確認する** — ユーザーのプランで利用可能か確認する（下記「Subscription Plans & API Availability」参照）。プランが不明な場合は、コマンドを提示しつつ必要プランを明記する
 3. **フィールド名を確認する** — `-f` で絞り込む前に `jquants schema <endpoint>` で正確な名前を調べる（推測しない）
 4. **個別API vs バルクを選ぶ** — 「全銘柄」「1ヶ月以上」「大量」のいずれかに該当 → バルク（references/commands-bulk.md 参照）。個別APIを大量に繰り返すとレートリミットに抵触するため（下記 Rate Limits 参照）。**Free プランは CSV/バルク不可**（`mkt calendar` を除く）
@@ -139,11 +140,19 @@ jquants --output json schema    # JSON 形式で出力
 | オプション四本値 | `jquants deriv options` | 日次 27:00頃 |
 | 日経225オプション | `jquants deriv options-225` | 日次 27:00頃 |
 
+### EDINET書類由来データ（edinet）※ Standard プラン以上
+| やりたいこと | コマンド | 更新時刻 |
+|---|---|---|
+| 大株主状況（有報） | `jquants edinet major-shareholders` | 随時（平日 8:00〜17:59） |
+| 政策保有株式（有報） | `jquants edinet cross-shareholdings` | 随時（平日 8:00〜17:59） |
+| 大量保有報告書 | `jquants edinet large-volume-shareholders` | 随時（平日 8:00〜17:59） |
+
 ### 財務データ（fins）
 | やりたいこと | コマンド | 更新時刻 |
 |---|---|---|
 | 財務諸表 | `jquants fins details` | 日次 18:00頃(速報) / 24:30頃(確報) |
 | 配当金情報 | `jquants fins dividend` | 日次 12〜19時頃 |
+| 決算発表予定日 | `jquants fins earnings-date` | 日次 10:05頃 |
 | 財務情報サマリー | `jquants fins summary` | 日次 18:00頃(速報) / 24:30頃(確報) |
 
 ### 指数データ（idx）
@@ -170,7 +179,8 @@ jquants --output json schema    # JSON 形式で出力
 | eq | references/commands-eq.md | 銘柄コード・日付・期間フィルタ、`eq trades` の特殊動作 |
 | mkt | references/commands-mkt.md | `--s33`, `--disc-date`/`--calc-date` 等の特殊フラグ |
 | deriv | references/commands-deriv.md | `--category`, `--contract-flag` の使い方 |
-| fins | references/commands-fins.md | `fins details` の FS フィールド（JSON出力必須） |
+| edinet | references/commands-edinet.md | ネスト項目の扱い・edinet_code/code の排他・3コマンドの個別仕様 |
+| fins | references/commands-fins.md | `fins details` の FS フィールド（JSON出力必須）、`fins earnings-date` の排他クエリ |
 | idx | references/commands-idx.md | 指数コード指定・TOPIX |
 | bulk | references/commands-bulk.md | バルクDLの判断基準・ワークフロー・エンドポイント一覧 |
 | td | references/commands-td.md | `--cursor` によるリアルタイムポーリング・`--download` の使い方・ファイル名規則 |
@@ -298,9 +308,9 @@ J-Quants API はプランごとに1分あたりのリクエスト上限が設定
 
 | 最低必要プラン | CLI コマンド |
 |---|---|
-| **Free** | `eq master`, `eq daily`, `eq earnings-calendar`, `fins summary`, `mkt calendar` |
+| **Free** | `eq master`, `eq daily`, `eq earnings-calendar`, `fins summary`, `fins earnings-date`, `mkt calendar` |
 | **Light** | `eq investor-types`, `idx daily-topix` |
-| **Standard** | `mkt margin-interest`, `mkt short-ratio`, `mkt short-sale-report`, `mkt margin-alert`, `idx daily`, `deriv options-225` |
+| **Standard** | `mkt margin-interest`, `mkt short-ratio`, `mkt short-sale-report`, `mkt margin-alert`, `idx daily`, `deriv options-225`, `edinet major-shareholders`, `edinet cross-shareholdings`, `edinet large-volume-shareholders` |
 | **Premium** | `eq am`, `fins details`, `fins dividend`, `mkt breakdown`, `deriv futures`, `deriv options` |
 | **Add-on** | `eq minute`, `eq trades`（分足・ティック専用アドオン契約が必要） |
 | **Add-on** | `td list`, `td files`, `td bulk`（TDnet/適時開示情報アドオン契約が必要） |
@@ -319,11 +329,13 @@ J-Quants API のデータは市場イベント後に順次更新される。**�
 
 | 更新時刻目安 | 反映されるデータ |
 |---|---|
+| 〜10:05 | 決算発表予定日（`fins earnings-date`）が当日公表分に更新 |
 | 〜12:00 | 前場四本値（`eq am`）が当日分に更新 |
 | 〜16:30 | 株価四本値・分足・ティック・指数・空売り比率・信用残（日次）が当日分に更新 |
 | 〜17:30 | 銘柄マスタ・空売り残高報告が更新 |
 | 〜18:00 | 売買内訳・投資部門別（週次）・財務情報（速報）が更新 |
-| 〜19:00 | 決算発表予定日が更新（不定期・JPX連動） |
+| 〜19:00 | 決算発表予定日（3・9月期のみ、`eq earnings-calendar`）が更新（不定期・JPX連動） |
+| 随時 | EDINET書類由来データ（`edinet` 系）が開示発生次第反映（平日 8:00〜17:59） |
 | 〜24:30 | 財務情報（確報）・財務諸表（確報）が更新 |
 | 〜27:00 | デリバティブ（先物・オプション）が当日分に更新（27:00 = 翌日3:00 AM） |
 

--- a/.claude/skills/jquants-cli-usage/references/commands-edinet.md
+++ b/.claude/skills/jquants-cli-usage/references/commands-edinet.md
@@ -1,0 +1,60 @@
+# Category: edinet (EDINET書類由来データ) — Command Reference
+
+いずれも **Standard プラン以上**で利用可能（Free / Light では 403）。
+過去データの参照範囲は Standard=10年 / Premium=20年。
+CSV/Bulk ダウンロードは非対応（API 経由のみ）。
+
+## 共通クエリ仕様（3コマンド共通）
+
+- `--edinet-code` / `--code` / `--date` はすべて**任意指定**
+- すべて省略した場合、**API 実行日に提出された全書類**のデータが返る
+- `--edinet-code` と `--code` の**同時指定は不可**（CLI が実行前に拒否する）
+
+```sh
+jquants edinet major-shareholders                           # 実行日提出分の一覧
+jquants edinet major-shareholders --code 86970              # 銘柄コード指定
+jquants edinet cross-shareholdings --edinet-code E02367     # EDINETコード指定
+jquants edinet large-volume-shareholders --date 2026-07-01  # 提出日指定
+```
+
+## ネスト構造の扱い（重要）
+
+3コマンドともレスポンスにネスト項目を含む:
+
+| コマンド | ネスト項目 | 内容 |
+|---|---|---|
+| major-shareholders | `Hldrs`（配列） | 大株主明細（Rank/HldrName/HldrAddr/ShsHeld/ShsRatio） |
+| cross-shareholdings | `Report` / `Largest` / `SecondLargest`（オブジェクト） | 保有主体ブロック。内部に `Spec[]`（特定投資株式）/ `Deem[]`（みなし保有株式）の銘柄明細 |
+| large-volume-shareholders | `Hldrs`（配列） | 提出者・共同保有者明細。内部に `AcqDisp[]` / `BrwList[]` / `CredList[]` |
+
+- **テーブル表示**: ネストは `"N items"` / `"N keys"` に略される
+- **JSON 出力**: 完全表示（`--output json` を推奨）
+- **CSV 出力**: ネストは JSON 文字列として 1 セルに収められる
+
+```sh
+jquants --output json edinet major-shareholders --code 86970    # 完全表示
+jquants --output csv --save mjr.csv edinet major-shareholders --date 2026-06-11
+```
+
+## edinet major-shareholders — 大株主状況
+
+有価証券報告書（第三号様式）記載の大株主の状況。データ提供期間は 2016-06-01 以降。
+
+- 大株主は通常上位10名だが、同順位タイで11件以上・100%子会社等で1件のみのケースあり
+- `ShsRatio` は小数表現（0.1704 = 17.04%）
+
+## edinet cross-shareholdings — 政策保有株式
+
+有価証券報告書「株式の保有状況」記載の政策保有株式。データ提供期間は 2020-03-31 以降。
+
+- 提出会社（`Report`）/ 連結最大保有会社（`Largest`）/ 連結第二最大保有会社（`SecondLargest`）の3スコープ
+- 各スコープに上場/非上場別の集計と `Spec[]` / `Deem[]` の銘柄明細
+- 本 API のデータは LLM によるデータ修正が行われている
+
+## edinet large-volume-shareholders — 大量保有報告書
+
+大量保有報告書・変更報告書（書類種別コード 350）の発行者・提出者情報。提出日 2021-07-01 以降。
+
+- `LargeHldgTypeCode`: 1=大量保有報告書 / 2=変更報告書 / 3=変更報告書(短期大量譲渡) / 4・5=特例対象 / 0=不明
+- `ChgRsn` / `TotalShsRatioLast` / `ShsRatioLast` は**変更報告書のみ**記載（それ以外は空）
+- `--edinet-code` / `--code` は**発行者**（保有される側）のコードを指定する

--- a/.claude/skills/jquants-cli-usage/references/commands-fins.md
+++ b/.claude/skills/jquants-cli-usage/references/commands-fins.md
@@ -35,6 +35,24 @@ jquants fins dividend --date 2021-09-01
 jquants fins dividend --from 2021-09-01 --to 2021-12-31
 ```
 
+## fins earnings-date — 決算発表予定日
+
+決算期によらず、報告を行った全上場銘柄（REIT等を含む）の決算発表予定日。
+変更・未定の履歴を公表日単位で提供する。
+
+```sh
+jquants fins earnings-date --code 86970                 # 銘柄の予定日公表履歴
+jquants fins earnings-date --date 2026-06-03            # 指定日に公表・変更された全銘柄の予定日
+jquants fins earnings-date --scheduled-date 2026-08-05  # 指定日を現在有効な予定日とする全銘柄
+```
+
+### 制約・特殊仕様
+
+- `--code` / `--date` / `--scheduled-date` は**いずれか1つの指定が必須**（2つ以上の同時指定は不可。CLI が実行前に拒否する）
+- 予定日が未定の場合、`SchDate` は**空文字**で返る
+- `--scheduled-date` は「現在有効な予定日」でのみヒットする。予定日がその後変更された場合、変更前の日付ではヒットしない
+- 旧 `eq earnings-calendar`（3・9月期決算会社のみ・翌営業日分）とは別の API
+
 ## fins summary — 財務情報サマリー
 
 ```sh

--- a/docs/en-US/README.md
+++ b/docs/en-US/README.md
@@ -153,12 +153,23 @@ jquants --output json eq earnings-calendar
 | `mkt short-ratio` | Sector short-selling ratio | `--s33`, `--date`, `--from`, `--to` |
 | `mkt short-sale-report` | Short sale report | `--code`, `--disc-date`, `--disc-date-from`, `--disc-date-to`, `--calc-date` |
 
+#### edinet — EDINET Documents
+
+| Subcommand | Description | Key Options |
+|---|---|---|
+| `edinet major-shareholders` | Major shareholders (annual securities reports) | `--edinet-code`, `--code`, `--date` |
+| `edinet cross-shareholdings` | Cross-shareholdings (annual securities reports) | `--edinet-code`, `--code`, `--date` |
+| `edinet large-volume-shareholders` | Large volume holding reports | `--edinet-code`, `--code`, `--date` |
+
+> Standard plan or higher is required. `--edinet-code` and `--code` cannot be specified together; if all options are omitted, documents submitted on the day of the API call are returned. Nested fields (`Hldrs`, `Report`, etc.) are summarized as item counts in table mode — use `--output json` for the full data.
+
 #### fins — Financials
 
 | Subcommand | Description | Key Options |
 |---|---|---|
 | `fins details` | Financial statements (BS/PL/CF) | `--code`, `--date` |
 | `fins dividend` | Dividend data | `--code`, `--date`, `--from`, `--to` |
+| `fins earnings-date` | Earnings announcement dates | `--code`, `--date`, `--scheduled-date` (exactly one required) |
 | `fins summary` | Financial summary | `--code`, `--date` |
 
 > In table mode, the `fins details` FS column shows only the item count. Use `--output json` to retrieve the full financial statement data.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -120,6 +120,22 @@ Examples:
         #[command(subcommand)]
         command: DerivativesCommands,
     },
+    /// EDINET-related API endpoints (EDINET書類由来データ)
+    #[command(name = "edinet")]
+    #[command(after_long_help = "\
+Examples:
+  jquants edinet major-shareholders --code 86970              # 大株主状況（有報）
+  jquants edinet cross-shareholdings --edinet-code E02367     # 政策保有株式（有報）
+  jquants edinet large-volume-shareholders --date 2026-07-01  # 指定日提出の大量保有報告書
+  jquants edinet major-shareholders                           # API実行日提出分の一覧
+
+Note: いずれも Standard プラン以上。--edinet-code と --code の同時指定は不可。
+      ネスト項目（Hldrs / Report 等）はテーブル表示では件数に略される。--output json で完全表示。
+      指定なしの全件取得は提出が多い日にデータ量が大きくなるため、--date や --code での絞り込みを推奨。")]
+    Edinet {
+        #[command(subcommand)]
+        command: EdinetCommands,
+    },
     /// Fins-related API endpoints (財務)
     #[command(name = "fins")]
     #[command(after_long_help = "\
@@ -464,6 +480,58 @@ pub enum DerivativesCommands {
 }
 
 #[derive(Subcommand)]
+pub enum EdinetCommands {
+    /// Fetch major shareholders from annual reports (大株主状況)
+    #[command(name = "major-shareholders")]
+    #[command(group = clap::ArgGroup::new("issuer").multiple(false))]
+    MajorShareholders {
+        /// EDINET code (e.g. E03814)
+        #[arg(long, group = "issuer")]
+        edinet_code: Option<String>,
+
+        /// Stock code
+        #[arg(long, group = "issuer")]
+        code: Option<String>,
+
+        /// Submission date (YYYY-MM-DD)
+        #[arg(long)]
+        date: Option<String>,
+    },
+    /// Fetch cross-shareholdings from annual reports (政策保有株式)
+    #[command(name = "cross-shareholdings")]
+    #[command(group = clap::ArgGroup::new("issuer").multiple(false))]
+    CrossShareholdings {
+        /// EDINET code (e.g. E02367)
+        #[arg(long, group = "issuer")]
+        edinet_code: Option<String>,
+
+        /// Stock code
+        #[arg(long, group = "issuer")]
+        code: Option<String>,
+
+        /// Submission date (YYYY-MM-DD)
+        #[arg(long)]
+        date: Option<String>,
+    },
+    /// Fetch large volume holding reports (大量保有報告書)
+    #[command(name = "large-volume-shareholders")]
+    #[command(group = clap::ArgGroup::new("issuer").multiple(false))]
+    LargeVolumeShareholders {
+        /// Issuer EDINET code (e.g. E03814)
+        #[arg(long, group = "issuer")]
+        edinet_code: Option<String>,
+
+        /// Issuer stock code
+        #[arg(long, group = "issuer")]
+        code: Option<String>,
+
+        /// Submission date (YYYY-MM-DD)
+        #[arg(long)]
+        date: Option<String>,
+    },
+}
+
+#[derive(Subcommand)]
 pub enum FinsCommands {
     /// Fetch financial statements (財務諸表)
     #[command(long_about = "Fetch financial statements (BS/PL/CF) (財務諸表)")]
@@ -507,6 +575,31 @@ Examples:
         /// End date (YYYY-MM-DD)
         #[arg(long)]
         to: Option<String>,
+    },
+    /// Fetch earnings announcement dates (決算発表予定日)
+    #[command(name = "earnings-date")]
+    #[command(long_about = "Fetch earnings announcement dates (決算発表予定日)")]
+    #[command(after_long_help = "\
+Note: code / date / scheduled_date のいずれか1つの指定が必須（2つ以上の同時指定は不可）。
+      予定日が未定の場合、SchDate は空文字で返る。
+
+Examples:
+  jquants fins earnings-date --code 86970                 # 銘柄の予定日公表履歴
+  jquants fins earnings-date --date 2026-06-03            # 指定日に公表・変更された全銘柄の予定日
+  jquants fins earnings-date --scheduled-date 2026-08-05  # 指定日を現在有効な予定日とする全銘柄")]
+    #[command(group = clap::ArgGroup::new("query").required(true).multiple(false))]
+    EarningsDate {
+        /// Stock code
+        #[arg(long, group = "query")]
+        code: Option<String>,
+
+        /// Publication date (YYYY-MM-DD)
+        #[arg(long, group = "query")]
+        date: Option<String>,
+
+        /// Scheduled announcement date (YYYY-MM-DD)
+        #[arg(long, group = "query")]
+        scheduled_date: Option<String>,
     },
     /// Fetch financial summary (財務情報サマリー)
     #[command(after_long_help = "\

--- a/src/client.rs
+++ b/src/client.rs
@@ -2,9 +2,10 @@ use crate::config::Config;
 use crate::error::AppError;
 use crate::models::{
     AmBar, ApiErrorResponse, ApiResponse, Breakdown, BulkGetResponse, BulkListItem, Calendar,
-    DailyBar, EarningsCalendar, FinsDetails, FinsDividend, FinsSummary, FuturesBar, IndexDailyBar,
-    InvestorType, MarginAlert, MarginInterest, MinuteBar, Options225Bar, OptionsBar, ShortRatio,
-    ShortSaleReport, StockMaster, TdBulk, TdFiles, TdList, TopixDailyBar,
+    DailyBar, EarningsCalendar, EdinetCrossShareholdings, EdinetLargeVolumeShareholders,
+    EdinetMajorShareholders, FinsDetails, FinsDividend, FinsEarningsDate, FinsSummary, FuturesBar,
+    IndexDailyBar, InvestorType, MarginAlert, MarginInterest, MinuteBar, Options225Bar, OptionsBar,
+    ShortRatio, ShortSaleReport, StockMaster, TdBulk, TdFiles, TdList, TopixDailyBar,
 };
 use reqwest::Client;
 
@@ -281,6 +282,20 @@ impl JQuantsClient {
         self.fetch_paginated("/fins/dividend", params).await
     }
 
+    pub async fn get_fins_earnings_date(
+        &self,
+        code: Option<&str>,
+        date: Option<&str>,
+        scheduled_date: Option<&str>,
+    ) -> Result<Vec<FinsEarningsDate>, AppError> {
+        let params = build_params(&[
+            ("code", code),
+            ("date", date),
+            ("scheduled_date", scheduled_date),
+        ]);
+        self.fetch_paginated("/fins/earnings-date", params).await
+    }
+
     pub async fn get_fins_summary(
         &self,
         code: Option<&str>,
@@ -325,6 +340,39 @@ impl JQuantsClient {
         }
 
         Ok((all_results, response_cursor))
+    }
+
+    pub async fn get_edinet_major_shareholders(
+        &self,
+        edinet_code: Option<&str>,
+        code: Option<&str>,
+        date: Option<&str>,
+    ) -> Result<Vec<EdinetMajorShareholders>, AppError> {
+        let params = build_params(&[("edinet_code", edinet_code), ("code", code), ("date", date)]);
+        self.fetch_paginated("/edinet/major-shareholders", params)
+            .await
+    }
+
+    pub async fn get_edinet_cross_shareholdings(
+        &self,
+        edinet_code: Option<&str>,
+        code: Option<&str>,
+        date: Option<&str>,
+    ) -> Result<Vec<EdinetCrossShareholdings>, AppError> {
+        let params = build_params(&[("edinet_code", edinet_code), ("code", code), ("date", date)]);
+        self.fetch_paginated("/edinet/cross-shareholdings", params)
+            .await
+    }
+
+    pub async fn get_edinet_large_volume_shareholders(
+        &self,
+        edinet_code: Option<&str>,
+        code: Option<&str>,
+        date: Option<&str>,
+    ) -> Result<Vec<EdinetLargeVolumeShareholders>, AppError> {
+        let params = build_params(&[("edinet_code", edinet_code), ("code", code), ("date", date)]);
+        self.fetch_paginated("/edinet/large-volume-shareholders", params)
+            .await
     }
 
     pub async fn get_topix_daily_bars(

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,15 +2,17 @@ use clap::{CommandFactory, Parser};
 use include_dir::{include_dir, Dir};
 use jquants_cli::auth::{login, logout};
 use jquants_cli::cli::{
-    BulkCommands, Cli, Commands, DerivativesCommands, EquitiesCommands, FinsCommands,
-    IndicesCommands, MarketsCommands, OutputFormat, SkillsCommands, TdCommands,
+    BulkCommands, Cli, Commands, DerivativesCommands, EdinetCommands, EquitiesCommands,
+    FinsCommands, IndicesCommands, MarketsCommands, OutputFormat, SkillsCommands, TdCommands,
 };
 use jquants_cli::client::JQuantsClient;
 use jquants_cli::config::Config;
 use jquants_cli::download::{download_bulk_file, download_td_files, handle_bulk_download};
 use jquants_cli::error;
 use jquants_cli::output::{
-    output, output_fins_details, output_margin_alert, output_td_files, FieldSelection,
+    output, output_edinet_cross_shareholdings, output_edinet_large_volume_shareholders,
+    output_edinet_major_shareholders, output_fins_details, output_margin_alert, output_td_files,
+    output_td_list, FieldSelection,
 };
 use jquants_cli::schema::{all_endpoint_keys, all_endpoint_schemas, lookup_endpoint};
 
@@ -353,6 +355,16 @@ async fn run_fins(
                 .await?;
             output(&results, out_fmt, save, fields)?;
         }
+        FinsCommands::EarningsDate {
+            code,
+            date,
+            scheduled_date,
+        } => {
+            let results = client
+                .get_fins_earnings_date(code.as_deref(), date.as_deref(), scheduled_date.as_deref())
+                .await?;
+            output(&results, out_fmt, save, fields)?;
+        }
         FinsCommands::Summary { code, date, cursor } => {
             let (results, response_cursor) = client
                 .get_fins_summary(code.as_deref(), date.as_deref(), cursor.as_deref())
@@ -361,6 +373,60 @@ async fn run_fins(
             if let Some(c) = response_cursor {
                 eprintln!("cursor: {c}");
             }
+        }
+    }
+    Ok(())
+}
+
+async fn run_edinet(
+    client: &JQuantsClient,
+    out_fmt: &OutputFormat,
+    save: &Option<String>,
+    fields: &FieldSelection,
+    command: EdinetCommands,
+) -> Result<(), error::AppError> {
+    match command {
+        EdinetCommands::MajorShareholders {
+            edinet_code,
+            code,
+            date,
+        } => {
+            let results = client
+                .get_edinet_major_shareholders(
+                    edinet_code.as_deref(),
+                    code.as_deref(),
+                    date.as_deref(),
+                )
+                .await?;
+            output_edinet_major_shareholders(&results, out_fmt, save, fields)?;
+        }
+        EdinetCommands::CrossShareholdings {
+            edinet_code,
+            code,
+            date,
+        } => {
+            let results = client
+                .get_edinet_cross_shareholdings(
+                    edinet_code.as_deref(),
+                    code.as_deref(),
+                    date.as_deref(),
+                )
+                .await?;
+            output_edinet_cross_shareholdings(&results, out_fmt, save, fields)?;
+        }
+        EdinetCommands::LargeVolumeShareholders {
+            edinet_code,
+            code,
+            date,
+        } => {
+            let results = client
+                .get_edinet_large_volume_shareholders(
+                    edinet_code.as_deref(),
+                    code.as_deref(),
+                    date.as_deref(),
+                )
+                .await?;
+            output_edinet_large_volume_shareholders(&results, out_fmt, save, fields)?;
         }
     }
     Ok(())
@@ -426,7 +492,7 @@ async fn run_td(
                     cursor.as_deref(),
                 )
                 .await?;
-            output(&results, out_fmt, save, fields)?;
+            output_td_list(&results, out_fmt, save, fields)?;
             if let Some(c) = response_cursor {
                 eprintln!("cursor: {c}");
             }
@@ -590,9 +656,7 @@ async fn run() -> Result<(), error::AppError> {
     }
 
     // --fields の空ベクタは未指定扱い（-f "" や -f "," のケース）
-    let fields: FieldSelection = cli
-        .fields
-        .and_then(|v| if v.is_empty() { None } else { Some(v) });
+    let fields: FieldSelection = cli.fields.filter(|v| !v.is_empty());
 
     if let Commands::Schema { ref endpoint } = cli.command {
         return run_schema(&cli.output, &cli.save, &fields, endpoint.as_deref());
@@ -610,6 +674,9 @@ async fn run() -> Result<(), error::AppError> {
         }
         Commands::Derivatives { command } => {
             run_derivatives(&client, &cli.output, &cli.save, &fields, command).await?;
+        }
+        Commands::Edinet { command } => {
+            run_edinet(&client, &cli.output, &cli.save, &fields, command).await?;
         }
         Commands::Fins { command } => {
             run_fins(&client, &cli.output, &cli.save, &fields, command).await?;

--- a/src/models.rs
+++ b/src/models.rs
@@ -247,6 +247,10 @@ pub struct DailyBar {
     pub afternoon_adj_close: Option<f64>,
     #[serde(rename = "AAdjVo")]
     pub afternoon_adj_volume: Option<f64>,
+    #[serde(rename = "MktCap")]
+    pub mkt_cap: Option<f64>,
+    #[serde(rename = "ExRT")]
+    pub ex_rt: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -782,6 +786,129 @@ pub struct FinsSummary {
     pub nx_f_nc_np: FlexString,
     #[serde(rename = "NxFNCEPS")]
     pub nx_f_nc_eps: FlexString,
+    #[serde(rename = "ShEq")]
+    pub sh_eq: FlexString,
+    #[serde(rename = "NCShEq")]
+    pub nc_sh_eq: FlexString,
+    #[serde(rename = "ROE")]
+    pub roe: FlexString,
+    #[serde(rename = "NCROE")]
+    pub nc_roe: FlexString,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct FinsEarningsDate {
+    #[serde(rename = "PubDate")]
+    pub pub_date: String,
+    #[serde(rename = "SchDate")]
+    pub sch_date: String,
+    #[serde(rename = "FQName")]
+    pub fq_name: String,
+    #[serde(rename = "FYE")]
+    pub fye: String,
+    #[serde(rename = "Code")]
+    pub code: String,
+    #[serde(rename = "CoName")]
+    pub co_name: String,
+    #[serde(rename = "CoNameEn")]
+    pub co_name_en: String,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct EdinetMajorShareholders {
+    #[serde(rename = "DocId")]
+    pub doc_id: String,
+    #[serde(rename = "Code")]
+    pub code: String,
+    #[serde(rename = "EdinetCode")]
+    pub edinet_code: String,
+    #[serde(rename = "FilerName")]
+    pub filer_name: String,
+    #[serde(rename = "FilerNameEn")]
+    pub filer_name_en: String,
+    #[serde(rename = "DocTypeCode")]
+    pub doc_type_code: String,
+    #[serde(rename = "SubDate")]
+    pub sub_date: String,
+    #[serde(rename = "SubTime")]
+    pub sub_time: String,
+    #[serde(rename = "PerSt")]
+    pub per_st: String,
+    #[serde(rename = "PerEn")]
+    pub per_en: String,
+    /// 大株主レコード配列（Rank/HldrName/HldrAddr/ShsHeld/ShsRatio）
+    #[serde(rename = "Hldrs")]
+    pub hldrs: Value,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct EdinetCrossShareholdings {
+    #[serde(rename = "DocId")]
+    pub doc_id: String,
+    #[serde(rename = "Code")]
+    pub code: String,
+    #[serde(rename = "EdinetCode")]
+    pub edinet_code: String,
+    #[serde(rename = "FilerName")]
+    pub filer_name: String,
+    #[serde(rename = "FilerNameEn")]
+    pub filer_name_en: String,
+    #[serde(rename = "DocTypeCode")]
+    pub doc_type_code: String,
+    #[serde(rename = "SubDate")]
+    pub sub_date: String,
+    #[serde(rename = "SubTime")]
+    pub sub_time: String,
+    #[serde(rename = "PerSt")]
+    pub per_st: String,
+    #[serde(rename = "PerEn")]
+    pub per_en: String,
+    /// 提出会社自身の保有ブロック（上場/非上場別集計・Spec[]/Deem[] 銘柄明細）
+    #[serde(rename = "Report")]
+    pub report: Value,
+    /// 連結最大保有会社の保有ブロック
+    #[serde(rename = "Largest")]
+    pub largest: Value,
+    /// 連結第二最大保有会社の保有ブロック
+    #[serde(rename = "SecondLargest")]
+    pub second_largest: Value,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct EdinetLargeVolumeShareholders {
+    #[serde(rename = "DocId")]
+    pub doc_id: String,
+    #[serde(rename = "Code")]
+    pub code: String,
+    #[serde(rename = "EdinetCode")]
+    pub edinet_code: String,
+    #[serde(rename = "IsrName")]
+    pub isr_name: String,
+    #[serde(rename = "DocTypeCode")]
+    pub doc_type_code: String,
+    #[serde(rename = "SubDate")]
+    pub sub_date: String,
+    #[serde(rename = "SubTime")]
+    pub sub_time: String,
+    #[serde(rename = "LargeHldgTypeCode")]
+    pub large_hldg_type_code: String,
+    #[serde(rename = "DocTitle")]
+    pub doc_title: String,
+    /// 変更事由（変更報告書のみ記載）
+    #[serde(rename = "ChgRsn")]
+    pub chg_rsn: FlexString,
+    #[serde(rename = "TotalShsHeld")]
+    pub total_shs_held: FlexString,
+    #[serde(rename = "TotalShsRatio")]
+    pub total_shs_ratio: FlexString,
+    /// 直前報告書の保有割合合計（変更報告書のみ記載）
+    #[serde(rename = "TotalShsRatioLast")]
+    pub total_shs_ratio_last: FlexString,
+    #[serde(rename = "TotalOutStks")]
+    pub total_out_stks: FlexString,
+    /// 提出者及び共同保有者のレコード配列（AcqDisp[]/BrwList[]/CredList[] を含む）
+    #[serde(rename = "Hldrs")]
+    pub hldrs: Value,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -1139,6 +1266,200 @@ mod tests {
         assert_eq!(response.data[0].code, "86970");
         assert_eq!(response.data[0].co_name, "日本取引所グループ");
         assert!(response.pagination_key.is_none());
+    }
+
+    #[test]
+    fn test_deserialize_fins_earnings_date_response() {
+        let json = r#"{
+            "data": [
+                {
+                    "PubDate": "2025-06-03",
+                    "SchDate": "2025-07-30",
+                    "FQName": "1Q",
+                    "FYE": "0331",
+                    "Code": "86970",
+                    "CoName": "日本取引所グループ",
+                    "CoNameEn": "Japan Exchange Group,Inc."
+                },
+                {
+                    "PubDate": "2025-08-01",
+                    "SchDate": "",
+                    "FQName": "2Q",
+                    "FYE": "0331",
+                    "Code": "86970",
+                    "CoName": "日本取引所グループ",
+                    "CoNameEn": "Japan Exchange Group,Inc."
+                }
+            ],
+            "pagination_key": null
+        }"#;
+
+        let response: ApiResponse<FinsEarningsDate> = serde_json::from_str(json).unwrap();
+        assert_eq!(response.data.len(), 2);
+        assert_eq!(response.data[0].sch_date, "2025-07-30");
+        assert_eq!(response.data[1].sch_date, "", "未定は空文字で返る");
+        assert_eq!(response.data[0].fye, "0331");
+    }
+
+    #[test]
+    fn test_deserialize_daily_bar_with_mktcap_and_exrt() {
+        let json = r#"{
+            "data": [
+                {
+                    "Date": "2026-08-07",
+                    "Code": "86970",
+                    "O": 2047.0,
+                    "H": 2069.0,
+                    "L": 2035.0,
+                    "C": 2045.0,
+                    "MktCap": 1083850.0,
+                    "ExRT": "1"
+                },
+                {
+                    "Date": "2026-08-07",
+                    "Code": "13260",
+                    "MktCap": null,
+                    "ExRT": null
+                }
+            ],
+            "pagination_key": null
+        }"#;
+
+        let response: ApiResponse<DailyBar> = serde_json::from_str(json).unwrap();
+        assert_eq!(response.data.len(), 2);
+        assert_eq!(response.data[0].mkt_cap, Some(1083850.0));
+        assert_eq!(response.data[0].ex_rt.as_deref(), Some("1"));
+        assert!(
+            response.data[1].mkt_cap.is_none(),
+            "ETF等・取引なし日は null → None"
+        );
+        assert!(
+            response.data[1].ex_rt.is_none(),
+            "権利落ちが無い日は null → None"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_edinet_major_shareholders_response() {
+        let json = r#"{
+            "data": [
+                {
+                    "DocId": "S100YA84",
+                    "Code": "86970",
+                    "EdinetCode": "E03814",
+                    "FilerName": "株式会社日本取引所グループ",
+                    "FilerNameEn": "Japan Exchange Group, Inc.",
+                    "DocTypeCode": "120",
+                    "SubDate": "2026-06-11",
+                    "SubTime": "10:43:00",
+                    "PerSt": "2025-04-01",
+                    "PerEn": "2026-03-31",
+                    "Hldrs": [
+                        {
+                            "Rank": 1,
+                            "HldrName": "日本マスタートラスト信託銀行株式会社（信託口）",
+                            "HldrAddr": "東京都港区",
+                            "ShsHeld": 175830000,
+                            "ShsRatio": 0.1704
+                        }
+                    ]
+                }
+            ],
+            "pagination_key": null
+        }"#;
+
+        let response: ApiResponse<EdinetMajorShareholders> = serde_json::from_str(json).unwrap();
+        assert_eq!(response.data.len(), 1);
+        let doc = &response.data[0];
+        assert_eq!(doc.code, "86970");
+        assert!(doc.hldrs.is_array(), "Hldrs は配列のまま保持される");
+        assert_eq!(doc.hldrs.as_array().unwrap().len(), 1);
+        assert_eq!(doc.hldrs[0]["Rank"], 1);
+    }
+
+    #[test]
+    fn test_deserialize_edinet_cross_shareholdings_with_null_block() {
+        // 提出会社自身が最大保有会社の場合、Largest は null で返る（実データで確認済みのパターン）
+        let json = r#"{
+            "data": [
+                {
+                    "DocId": "S100YA84",
+                    "Code": "86970",
+                    "EdinetCode": "E03814",
+                    "FilerName": "株式会社日本取引所グループ",
+                    "FilerNameEn": "Japan Exchange Group, Inc.",
+                    "DocTypeCode": "120",
+                    "SubDate": "2026-06-11",
+                    "SubTime": "10:43:00",
+                    "PerSt": "2025-04-01",
+                    "PerEn": "2026-03-31",
+                    "Report": {
+                        "HldrName": "株式会社日本取引所グループ",
+                        "NonListedIss": 6,
+                        "Spec": [],
+                        "Deem": []
+                    },
+                    "Largest": null,
+                    "SecondLargest": {
+                        "HldrName": "株式会社東京証券取引所",
+                        "NonListedIss": 2,
+                        "Spec": [],
+                        "Deem": []
+                    }
+                }
+            ],
+            "pagination_key": null
+        }"#;
+
+        let response: ApiResponse<EdinetCrossShareholdings> = serde_json::from_str(json).unwrap();
+        let doc = &response.data[0];
+        assert!(doc.report.is_object());
+        assert!(doc.largest.is_null(), "最大保有会社=提出会社の場合は null");
+        assert_eq!(doc.second_largest["HldrName"], "株式会社東京証券取引所");
+    }
+
+    #[test]
+    fn test_deserialize_edinet_large_volume_shareholders_response() {
+        // 大量保有報告書（初回）は ChgRsn / TotalShsRatioLast が null（変更報告書のみ記載のため）
+        let json = r#"{
+            "data": [
+                {
+                    "DocId": "S100ZZZZ",
+                    "Code": "86970",
+                    "EdinetCode": "E03814",
+                    "IsrName": "株式会社日本取引所グループ",
+                    "DocTypeCode": "350",
+                    "SubDate": "2026-07-01",
+                    "SubTime": "10:00:00",
+                    "LargeHldgTypeCode": "1",
+                    "DocTitle": "大量保有報告書",
+                    "ChgRsn": null,
+                    "TotalShsHeld": 71000000,
+                    "TotalShsRatio": 0.0572,
+                    "TotalShsRatioLast": null,
+                    "TotalOutStks": 1241000000,
+                    "Hldrs": [
+                        {
+                            "HldrName": "テスト保有者",
+                            "ShsHeld": 71000000,
+                            "ShsRatio": 0.0572,
+                            "AcqDisp": [],
+                            "BrwList": [],
+                            "CredList": []
+                        }
+                    ]
+                }
+            ],
+            "pagination_key": null
+        }"#;
+
+        let response: ApiResponse<EdinetLargeVolumeShareholders> =
+            serde_json::from_str(json).unwrap();
+        let doc = &response.data[0];
+        assert_eq!(doc.chg_rsn.0, "", "null は FlexString で空文字になる");
+        assert_eq!(doc.total_shs_ratio_last.0, "");
+        assert_eq!(doc.total_shs_ratio.0, "0.0572");
+        assert!(doc.hldrs.is_array());
     }
 
     #[test]

--- a/src/output.rs
+++ b/src/output.rs
@@ -1,8 +1,9 @@
 use crate::cli::OutputFormat;
 use crate::error::AppError;
 use crate::models::{
-    AmBar, Breakdown, BulkListItem, Calendar, DailyBar, EarningsCalendar, FinsDetails,
-    FinsDividend, FinsSummary, FuturesBar, IndexDailyBar, InvestorType, MarginAlert,
+    AmBar, Breakdown, BulkListItem, Calendar, DailyBar, EarningsCalendar, EdinetCrossShareholdings,
+    EdinetLargeVolumeShareholders, EdinetMajorShareholders, FinsDetails, FinsDividend,
+    FinsEarningsDate, FinsSummary, FuturesBar, IndexDailyBar, InvestorType, MarginAlert,
     MarginInterest, MinuteBar, Options225Bar, OptionsBar, ShortRatio, ShortSaleReport, StockMaster,
     TdBulk, TdFiles, TdList, TopixDailyBar,
 };
@@ -260,6 +261,25 @@ impl TableDisplay for FinsSummary {
     }
 }
 
+impl TableDisplay for FinsEarningsDate {
+    fn table_headers() -> Vec<&'static str> {
+        vec![
+            "PubDate", "SchDate", "FQName", "FYE", "Code", "CoName", "CoNameEn",
+        ]
+    }
+    fn table_row(&self) -> Vec<String> {
+        vec![
+            self.pub_date.clone(),
+            self.sch_date.clone(),
+            self.fq_name.clone(),
+            self.fye.clone(),
+            self.code.clone(),
+            self.co_name.clone(),
+            self.co_name_en.clone(),
+        ]
+    }
+}
+
 impl TableDisplay for TopixDailyBar {
     fn table_headers() -> Vec<&'static str> {
         vec!["Date", "Open", "High", "Low", "Close"]
@@ -424,6 +444,74 @@ impl TableDisplay for FinsDetails {
     }
 }
 
+impl TableDisplay for EdinetMajorShareholders {
+    fn table_headers() -> Vec<&'static str> {
+        vec!["DocId", "Code", "FilerName", "SubDate", "PerEn", "Hldrs"]
+    }
+    fn table_row(&self) -> Vec<String> {
+        vec![
+            self.doc_id.clone(),
+            self.code.clone(),
+            self.filer_name.clone(),
+            self.sub_date.clone(),
+            self.per_en.clone(),
+            nested_value_summary(&self.hldrs),
+        ]
+    }
+}
+
+impl TableDisplay for EdinetCrossShareholdings {
+    fn table_headers() -> Vec<&'static str> {
+        vec![
+            "DocId",
+            "Code",
+            "FilerName",
+            "SubDate",
+            "PerEn",
+            "Report",
+            "Largest",
+            "SecondLargest",
+        ]
+    }
+    fn table_row(&self) -> Vec<String> {
+        vec![
+            self.doc_id.clone(),
+            self.code.clone(),
+            self.filer_name.clone(),
+            self.sub_date.clone(),
+            self.per_en.clone(),
+            nested_value_summary(&self.report),
+            nested_value_summary(&self.largest),
+            nested_value_summary(&self.second_largest),
+        ]
+    }
+}
+
+impl TableDisplay for EdinetLargeVolumeShareholders {
+    fn table_headers() -> Vec<&'static str> {
+        vec![
+            "DocId",
+            "Code",
+            "IsrName",
+            "SubDate",
+            "DocTitle",
+            "TotalShsRatio",
+            "Hldrs",
+        ]
+    }
+    fn table_row(&self) -> Vec<String> {
+        vec![
+            self.doc_id.clone(),
+            self.code.clone(),
+            self.isr_name.clone(),
+            self.sub_date.clone(),
+            self.doc_title.clone(),
+            self.total_shs_ratio.to_string(),
+            nested_value_summary(&self.hldrs),
+        ]
+    }
+}
+
 impl TableDisplay for TdBulk {
     fn table_headers() -> Vec<&'static str> {
         vec!["LastUpdated", "URL"]
@@ -557,6 +645,16 @@ fn fins_fs_keys_summary(fs: &serde_json::Value) -> String {
     match fs {
         serde_json::Value::Object(map) => format!("{} items", map.len()),
         _ => "-".to_string(),
+    }
+}
+
+/// ネスト値（配列/オブジェクト）をテーブル表示用に件数へ略記する
+fn nested_value_summary(v: &serde_json::Value) -> String {
+    match v {
+        serde_json::Value::Array(items) => format!("{} items", items.len()),
+        serde_json::Value::Object(map) => format!("{} keys", map.len()),
+        serde_json::Value::Null => "-".to_string(),
+        other => other.to_string(),
     }
 }
 
@@ -899,6 +997,213 @@ pub fn output_fins_details(
                 item.doc_type.as_str(),
                 fs_str.as_str(),
             ])?;
+        }
+        wtr.flush()?;
+        saved_notice(save);
+        Ok(())
+    } else {
+        output(results, format, save, fields)
+    }
+}
+
+/// EDINET 大株主状況の出力。CSV ではネストの Hldrs を JSON 文字列として 1 セルに収める
+pub fn output_edinet_major_shareholders(
+    results: &[EdinetMajorShareholders],
+    format: &OutputFormat,
+    save: &Option<String>,
+    fields: &FieldSelection,
+) -> Result<(), AppError> {
+    if let Some(ref field_list) = fields {
+        return output_filtered(results, field_list, format, save);
+    }
+    if let OutputFormat::Csv = format {
+        let mut wtr = csv::Writer::from_writer(make_writer(save)?);
+        wtr.write_record([
+            "DocId",
+            "Code",
+            "EdinetCode",
+            "FilerName",
+            "FilerNameEn",
+            "DocTypeCode",
+            "SubDate",
+            "SubTime",
+            "PerSt",
+            "PerEn",
+            "Hldrs",
+        ])?;
+        for item in results {
+            let row = vec![
+                item.doc_id.clone(),
+                item.code.clone(),
+                item.edinet_code.clone(),
+                item.filer_name.clone(),
+                item.filer_name_en.clone(),
+                item.doc_type_code.clone(),
+                item.sub_date.clone(),
+                item.sub_time.clone(),
+                item.per_st.clone(),
+                item.per_en.clone(),
+                serde_json::to_string(&item.hldrs)?,
+            ];
+            wtr.write_record(&row)?;
+        }
+        wtr.flush()?;
+        saved_notice(save);
+        Ok(())
+    } else {
+        output(results, format, save, fields)
+    }
+}
+
+/// EDINET 政策保有株式の出力。CSV では Report/Largest/SecondLargest を JSON 文字列として 1 セルに収める
+pub fn output_edinet_cross_shareholdings(
+    results: &[EdinetCrossShareholdings],
+    format: &OutputFormat,
+    save: &Option<String>,
+    fields: &FieldSelection,
+) -> Result<(), AppError> {
+    if let Some(ref field_list) = fields {
+        return output_filtered(results, field_list, format, save);
+    }
+    if let OutputFormat::Csv = format {
+        let mut wtr = csv::Writer::from_writer(make_writer(save)?);
+        wtr.write_record([
+            "DocId",
+            "Code",
+            "EdinetCode",
+            "FilerName",
+            "FilerNameEn",
+            "DocTypeCode",
+            "SubDate",
+            "SubTime",
+            "PerSt",
+            "PerEn",
+            "Report",
+            "Largest",
+            "SecondLargest",
+        ])?;
+        for item in results {
+            let row = vec![
+                item.doc_id.clone(),
+                item.code.clone(),
+                item.edinet_code.clone(),
+                item.filer_name.clone(),
+                item.filer_name_en.clone(),
+                item.doc_type_code.clone(),
+                item.sub_date.clone(),
+                item.sub_time.clone(),
+                item.per_st.clone(),
+                item.per_en.clone(),
+                serde_json::to_string(&item.report)?,
+                serde_json::to_string(&item.largest)?,
+                serde_json::to_string(&item.second_largest)?,
+            ];
+            wtr.write_record(&row)?;
+        }
+        wtr.flush()?;
+        saved_notice(save);
+        Ok(())
+    } else {
+        output(results, format, save, fields)
+    }
+}
+
+/// EDINET 大量保有報告書の出力。CSV ではネストの Hldrs を JSON 文字列として 1 セルに収める
+pub fn output_edinet_large_volume_shareholders(
+    results: &[EdinetLargeVolumeShareholders],
+    format: &OutputFormat,
+    save: &Option<String>,
+    fields: &FieldSelection,
+) -> Result<(), AppError> {
+    if let Some(ref field_list) = fields {
+        return output_filtered(results, field_list, format, save);
+    }
+    if let OutputFormat::Csv = format {
+        let mut wtr = csv::Writer::from_writer(make_writer(save)?);
+        wtr.write_record([
+            "DocId",
+            "Code",
+            "EdinetCode",
+            "IsrName",
+            "DocTypeCode",
+            "SubDate",
+            "SubTime",
+            "LargeHldgTypeCode",
+            "DocTitle",
+            "ChgRsn",
+            "TotalShsHeld",
+            "TotalShsRatio",
+            "TotalShsRatioLast",
+            "TotalOutStks",
+            "Hldrs",
+        ])?;
+        for item in results {
+            let row = vec![
+                item.doc_id.clone(),
+                item.code.clone(),
+                item.edinet_code.clone(),
+                item.isr_name.clone(),
+                item.doc_type_code.clone(),
+                item.sub_date.clone(),
+                item.sub_time.clone(),
+                item.large_hldg_type_code.clone(),
+                item.doc_title.clone(),
+                item.chg_rsn.to_string(),
+                item.total_shs_held.to_string(),
+                item.total_shs_ratio.to_string(),
+                item.total_shs_ratio_last.to_string(),
+                item.total_out_stks.to_string(),
+                serde_json::to_string(&item.hldrs)?,
+            ];
+            wtr.write_record(&row)?;
+        }
+        wtr.flush()?;
+        saved_notice(save);
+        Ok(())
+    } else {
+        output(results, format, save, fields)
+    }
+}
+
+/// TDnet 適時開示一覧の出力。CSV では配列の DiscItems/Docs を JSON 文字列として 1 セルに収める
+/// （汎用 output() の csv::serialize はネスト配列を扱えずエラーになるため）
+pub fn output_td_list(
+    results: &[TdList],
+    format: &OutputFormat,
+    save: &Option<String>,
+    fields: &FieldSelection,
+) -> Result<(), AppError> {
+    if let Some(ref field_list) = fields {
+        return output_filtered(results, field_list, format, save);
+    }
+    if let OutputFormat::Csv = format {
+        let mut wtr = csv::Writer::from_writer(make_writer(save)?);
+        wtr.write_record([
+            "DiscNo",
+            "Code",
+            "Name",
+            "DiscDate",
+            "DiscTime",
+            "Title",
+            "DiscStatus",
+            "RevNo",
+            "DiscItems",
+            "Docs",
+        ])?;
+        for item in results {
+            let row = vec![
+                item.disc_no.clone(),
+                item.code.clone(),
+                item.name.clone(),
+                item.disc_date.clone(),
+                item.disc_time.clone(),
+                item.title.clone(),
+                item.disc_status.clone().unwrap_or_default(),
+                item.rev_no.clone(),
+                serde_json::to_string(&item.disc_items)?,
+                serde_json::to_string(&item.docs)?,
+            ];
+            wtr.write_record(&row)?;
         }
         wtr.flush()?;
         saved_notice(save);

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,6 +1,7 @@
 use crate::models::{
-    AmBar, Breakdown, BulkListItem, Calendar, DailyBar, EarningsCalendar, FinsDetails,
-    FinsDividend, FinsSummary, FuturesBar, IndexDailyBar, InvestorType, MarginAlert,
+    AmBar, Breakdown, BulkListItem, Calendar, DailyBar, EarningsCalendar, EdinetCrossShareholdings,
+    EdinetLargeVolumeShareholders, EdinetMajorShareholders, FinsDetails, FinsDividend,
+    FinsEarningsDate, FinsSummary, FuturesBar, IndexDailyBar, InvestorType, MarginAlert,
     MarginInterest, MinuteBar, Options225Bar, OptionsBar, ShortRatio, ShortSaleReport, StockMaster,
     TdBulk, TdFiles, TdList, TopixDailyBar,
 };
@@ -474,10 +475,20 @@ impl SchemaInfo for DailyBar {
                 field_type: "number?",
                 description: "後場調整後出来高",
             },
+            FieldSchema {
+                name: "MktCap",
+                field_type: "number?",
+                description: "時価総額（百万円）。指数用株式数が無い銘柄（ETF・ETN等）や取引が存在しない日は null",
+            },
+            FieldSchema {
+                name: "ExRT",
+                field_type: "string?",
+                description: "権利落種類（1: 株式分割 / 2: 株式併合 / 3: ライツイシュー。株式無償割当は 1 に含む）。該当する権利落ちが無い日は null",
+            },
         ]
     }
     fn field_count() -> usize {
-        42
+        44
     }
 }
 
@@ -1882,6 +1893,300 @@ impl SchemaInfo for FinsDividend {
     }
 }
 
+impl SchemaInfo for EdinetMajorShareholders {
+    fn endpoint_key() -> &'static str {
+        "edinet.major-shareholders"
+    }
+    fn endpoint_description() -> &'static str {
+        "大株主状況（有価証券報告書記載・EDINET由来）"
+    }
+    fn field_schemas() -> Vec<FieldSchema> {
+        vec![
+            FieldSchema {
+                name: "DocId",
+                field_type: "string",
+                description: "EDINET 書類管理番号（S + 7桁英数字）",
+            },
+            FieldSchema {
+                name: "Code",
+                field_type: "string",
+                description: "提出会社の銘柄コード（5桁）",
+            },
+            FieldSchema {
+                name: "EdinetCode",
+                field_type: "string",
+                description: "提出会社の EDINET コード",
+            },
+            FieldSchema {
+                name: "FilerName",
+                field_type: "string",
+                description: "提出者名（会社名）",
+            },
+            FieldSchema {
+                name: "FilerNameEn",
+                field_type: "string",
+                description: "提出者名（英語）",
+            },
+            FieldSchema {
+                name: "DocTypeCode",
+                field_type: "string",
+                description: "書類種別コード（120 = 有価証券報告書）",
+            },
+            FieldSchema {
+                name: "SubDate",
+                field_type: "string",
+                description: "提出日 (YYYY-MM-DD)",
+            },
+            FieldSchema {
+                name: "SubTime",
+                field_type: "string",
+                description: "提出時刻 (HH:MM:SS)",
+            },
+            FieldSchema {
+                name: "PerSt",
+                field_type: "string",
+                description: "対象事業年度の開始日 (YYYY-MM-DD)",
+            },
+            FieldSchema {
+                name: "PerEn",
+                field_type: "string",
+                description: "対象事業年度の終了日 (YYYY-MM-DD)",
+            },
+            FieldSchema {
+                name: "Hldrs",
+                field_type: "array",
+                description: "大株主レコード配列（Rank/HldrName/HldrAddr/ShsHeld/ShsRatio。--output json で完全表示）",
+            },
+        ]
+    }
+    fn field_count() -> usize {
+        11
+    }
+}
+
+impl SchemaInfo for EdinetCrossShareholdings {
+    fn endpoint_key() -> &'static str {
+        "edinet.cross-shareholdings"
+    }
+    fn endpoint_description() -> &'static str {
+        "政策保有株式（有価証券報告書「株式の保有状況」・EDINET由来）"
+    }
+    fn field_schemas() -> Vec<FieldSchema> {
+        vec![
+            FieldSchema {
+                name: "DocId",
+                field_type: "string",
+                description: "EDINET 書類管理番号（S + 7桁英数字）",
+            },
+            FieldSchema {
+                name: "Code",
+                field_type: "string",
+                description: "提出会社の銘柄コード（5桁）",
+            },
+            FieldSchema {
+                name: "EdinetCode",
+                field_type: "string",
+                description: "提出会社の EDINET コード",
+            },
+            FieldSchema {
+                name: "FilerName",
+                field_type: "string",
+                description: "提出者名（会社名・和文）",
+            },
+            FieldSchema {
+                name: "FilerNameEn",
+                field_type: "string",
+                description: "提出者名（英文）",
+            },
+            FieldSchema {
+                name: "DocTypeCode",
+                field_type: "string",
+                description: "書類種別コード（120 = 有価証券報告書）",
+            },
+            FieldSchema {
+                name: "SubDate",
+                field_type: "string",
+                description: "提出日 (YYYY-MM-DD)",
+            },
+            FieldSchema {
+                name: "SubTime",
+                field_type: "string",
+                description: "提出時刻 (HH:MM:SS)",
+            },
+            FieldSchema {
+                name: "PerSt",
+                field_type: "string",
+                description: "対象事業年度の開始日 (YYYY-MM-DD)",
+            },
+            FieldSchema {
+                name: "PerEn",
+                field_type: "string",
+                description: "対象事業年度の終了日 (YYYY-MM-DD)",
+            },
+            FieldSchema {
+                name: "Report",
+                field_type: "object",
+                description: "提出会社自身の保有ブロック（上場/非上場別集計・Spec[]/Deem[] 銘柄明細。--output json で完全表示）",
+            },
+            FieldSchema {
+                name: "Largest",
+                field_type: "object",
+                description: "連結最大保有会社の保有ブロック（構造は Report と同じ）",
+            },
+            FieldSchema {
+                name: "SecondLargest",
+                field_type: "object",
+                description: "連結第二最大保有会社の保有ブロック（構造は Report と同じ）",
+            },
+        ]
+    }
+    fn field_count() -> usize {
+        13
+    }
+}
+
+impl SchemaInfo for EdinetLargeVolumeShareholders {
+    fn endpoint_key() -> &'static str {
+        "edinet.large-volume-shareholders"
+    }
+    fn endpoint_description() -> &'static str {
+        "大量保有報告書・変更報告書（発行者・提出者情報・EDINET由来）"
+    }
+    fn field_schemas() -> Vec<FieldSchema> {
+        vec![
+            FieldSchema {
+                name: "DocId",
+                field_type: "string",
+                description: "EDINET 書類管理番号（S + 7桁英数字）",
+            },
+            FieldSchema {
+                name: "Code",
+                field_type: "string",
+                description: "発行者（保有対象銘柄）の銘柄コード（5桁）",
+            },
+            FieldSchema {
+                name: "EdinetCode",
+                field_type: "string",
+                description: "発行者の EDINET コード",
+            },
+            FieldSchema {
+                name: "IsrName",
+                field_type: "string",
+                description: "発行者名",
+            },
+            FieldSchema {
+                name: "DocTypeCode",
+                field_type: "string",
+                description: "書類種別コード（350 = 大量保有報告書関連）",
+            },
+            FieldSchema {
+                name: "SubDate",
+                field_type: "string",
+                description: "提出日 (YYYY-MM-DD)",
+            },
+            FieldSchema {
+                name: "SubTime",
+                field_type: "string",
+                description: "提出時刻 (HH:MM:SS)",
+            },
+            FieldSchema {
+                name: "LargeHldgTypeCode",
+                field_type: "string",
+                description: "大量保有書類種別コード（1=大量保有報告書 / 2=変更報告書 / 3=変更報告書(短期大量譲渡) / 4=大量保有報告書(特例) / 5=変更報告書(特例) / 0=不明）",
+            },
+            FieldSchema {
+                name: "DocTitle",
+                field_type: "string",
+                description: "書類表題（e.g. 大量保有報告書）",
+            },
+            FieldSchema {
+                name: "ChgRsn",
+                field_type: "string",
+                description: "報告義務発生日における変更事由（変更報告書のみ）",
+            },
+            FieldSchema {
+                name: "TotalShsHeld",
+                field_type: "string",
+                description: "保有株券等の数の合計（株）",
+            },
+            FieldSchema {
+                name: "TotalShsRatio",
+                field_type: "string",
+                description: "株券等保有割合の合計。小数表現（0.1343 = 13.43%）",
+            },
+            FieldSchema {
+                name: "TotalShsRatioLast",
+                field_type: "string",
+                description: "直前の報告書に係る株券等保有割合の合計（変更報告書のみ）",
+            },
+            FieldSchema {
+                name: "TotalOutStks",
+                field_type: "string",
+                description: "発行済株式等総数（株）",
+            },
+            FieldSchema {
+                name: "Hldrs",
+                field_type: "array",
+                description: "提出者及び共同保有者のレコード配列（AcqDisp[]/BrwList[]/CredList[] を含む。--output json で完全表示）",
+            },
+        ]
+    }
+    fn field_count() -> usize {
+        15
+    }
+}
+
+impl SchemaInfo for FinsEarningsDate {
+    fn endpoint_key() -> &'static str {
+        "fins.earnings-date"
+    }
+    fn endpoint_description() -> &'static str {
+        "決算発表予定日（予定日の変更・未定の履歴を公表日単位で提供）"
+    }
+    fn field_schemas() -> Vec<FieldSchema> {
+        vec![
+            FieldSchema {
+                name: "PubDate",
+                field_type: "string",
+                description: "公表日 (YYYY-MM-DD)",
+            },
+            FieldSchema {
+                name: "SchDate",
+                field_type: "string",
+                description: "決算発表予定日 (YYYY-MM-DD)・未定の場合は空文字",
+            },
+            FieldSchema {
+                name: "FQName",
+                field_type: "string",
+                description: "決算区分 (1Q/2Q/3Q/FY)",
+            },
+            FieldSchema {
+                name: "FYE",
+                field_type: "string",
+                description: "決算期末 (MMDD)",
+            },
+            FieldSchema {
+                name: "Code",
+                field_type: "string",
+                description: "銘柄コード（5桁）",
+            },
+            FieldSchema {
+                name: "CoName",
+                field_type: "string",
+                description: "会社名",
+            },
+            FieldSchema {
+                name: "CoNameEn",
+                field_type: "string",
+                description: "会社名（英語）",
+            },
+        ]
+    }
+    fn field_count() -> usize {
+        7
+    }
+}
+
 impl SchemaInfo for FinsSummary {
     fn endpoint_key() -> &'static str {
         "fins.summary"
@@ -2442,10 +2747,30 @@ impl SchemaInfo for FinsSummary {
                 field_type: "string",
                 description: "連結EPS通期予想（翌期）",
             },
+            FieldSchema {
+                name: "ShEq",
+                field_type: "string",
+                description: "自己資本",
+            },
+            FieldSchema {
+                name: "NCShEq",
+                field_type: "string",
+                description: "自己資本_非連結",
+            },
+            FieldSchema {
+                name: "ROE",
+                field_type: "string",
+                description: "自己資本利益率",
+            },
+            FieldSchema {
+                name: "NCROE",
+                field_type: "string",
+                description: "自己資本利益率_非連結",
+            },
         ]
     }
     fn field_count() -> usize {
-        107
+        111
     }
 }
 
@@ -2740,8 +3065,10 @@ register_endpoints! {
     Breakdown, MarginAlert, MarginInterest, Calendar, ShortRatio, ShortSaleReport;
     // deriv グループ
     Options225Bar, FuturesBar, OptionsBar;
+    // edinet グループ
+    EdinetMajorShareholders, EdinetCrossShareholdings, EdinetLargeVolumeShareholders;
     // fins グループ
-    FinsDetails, FinsDividend, FinsSummary;
+    FinsDetails, FinsDividend, FinsEarningsDate, FinsSummary;
     // idx グループ
     TopixDailyBar, IndexDailyBar;
     // bulk グループ
@@ -2758,7 +3085,7 @@ mod tests {
 
     #[test]
     fn test_all_endpoints_count() {
-        assert_eq!(all_endpoint_schemas().len(), 24);
+        assert_eq!(all_endpoint_schemas().len(), 28);
     }
 
     #[test]


### PR DESCRIPTION
## 概要

J-Quants API V2 の新エンドポイント・新項目に対応します。

## 変更内容

- **`fins earnings-date` コマンドを追加**（決算発表予定日。`--code` / `--date` / `--scheduled-date` のいずれか 1 つ必須・clap の ArgGroup で実行前に検証）
- **`edinet` カテゴリを新設**: `major-shareholders` / `cross-shareholdings` / `large-volume-shareholders` の 3 コマンド（Standard プラン以上。ネスト項目はテーブルでは件数略記・CSV では JSON 文字列 1 セル・完全表示は `--output json`）
- **`fins summary` に 4 項目追加対応**（ShEq / NCShEq / ROE / NCROE）
- **`eq daily` に 2 項目追加対応**（MktCap / ExRT。null 許容のため Option 型）
- **`td list` の CSV 出力を修正**（配列フィールドでエラーになっていた問題。fins details と同様にネストを JSON 文字列で 1 セルに収める方式）
- スキーマ（`jquants schema`）・AI スキル・英語 README を追随更新

## テスト

- cargo fmt / clippy / test（65 passed）
- 実 API に対する e2e で全エンドポイント検証済み（新コマンド 4 本含む）
