### PR TITLE
fix: eq masterにProdCatフィールドを追加

### DIFF
--- a/src/models.rs
+++ b/src/models.rs
@@ -1258,7 +1258,7 @@ mod tests {
                     "MktNm": "プライム",
                     "Mrgn": "1",
                     "MrgnNm": "信用",
-                    "ProdCat": "0101"
+                    "ProdCat": "011"
                 }
             ],
             "pagination_key": null
@@ -1268,7 +1268,7 @@ mod tests {
         assert_eq!(response.data.len(), 1);
         assert_eq!(response.data[0].code, "86970");
         assert_eq!(response.data[0].co_name, "日本取引所グループ");
-        assert_eq!(response.data[0].product_category, "0101");
+        assert_eq!(response.data[0].product_category, "011");
         assert!(response.pagination_key.is_none());
     }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -80,6 +80,8 @@ pub struct StockMaster {
     pub margin_code: String,
     #[serde(rename = "MrgnNm")]
     pub margin_code_name: String,
+    #[serde(rename = "ProdCat")]
+    pub product_category: String,
 }
 
 #[derive(Debug, Deserialize, Serialize, Clone)]
@@ -1255,7 +1257,8 @@ mod tests {
                     "Mkt": "0111",
                     "MktNm": "プライム",
                     "Mrgn": "1",
-                    "MrgnNm": "信用"
+                    "MrgnNm": "信用",
+                    "ProdCat": "0101"
                 }
             ],
             "pagination_key": null
@@ -1265,6 +1268,7 @@ mod tests {
         assert_eq!(response.data.len(), 1);
         assert_eq!(response.data[0].code, "86970");
         assert_eq!(response.data[0].co_name, "日本取引所グループ");
+        assert_eq!(response.data[0].product_category, "0101");
         assert!(response.pagination_key.is_none());
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1289,7 +1289,7 @@ mod tests {
             market_code_name: "Prime".into(),
             margin_code: "1".into(),
             margin_code_name: "MarginOK".into(),
-            product_category: "0101".into(),
+            product_category: "011".into(),
         }
     }
 

--- a/src/output.rs
+++ b/src/output.rs
@@ -1289,6 +1289,7 @@ mod tests {
             market_code_name: "Prime".into(),
             margin_code: "1".into(),
             margin_code_name: "MarginOK".into(),
+            product_category: "0101".into(),
         }
     }
 
@@ -1350,7 +1351,7 @@ mod tests {
             col_names,
             vec![
                 "Date", "Code", "CoName", "CoNameEn", "S17", "S17Nm", "S33", "S33Nm", "ScaleCat",
-                "Mkt", "MktNm", "Mrgn", "MrgnNm"
+                "Mkt", "MktNm", "Mrgn", "MrgnNm", "ProdCat"
             ]
         );
 

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -132,7 +132,7 @@ impl SchemaInfo for StockMaster {
             FieldSchema {
                 name: "ProdCat",
                 field_type: "string",
-                description: "商品区分",
+                description: "商品区分コード",
             },
         ]
     }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -129,10 +129,15 @@ impl SchemaInfo for StockMaster {
                 field_type: "string",
                 description: "信用区分名（信用/貸借）",
             },
+            FieldSchema {
+                name: "ProdCat",
+                field_type: "string",
+                description: "商品区分",
+            },
         ]
     }
     fn field_count() -> usize {
-        13
+        14
     }
 }
 


### PR DESCRIPTION
## Summary
- `/equities/master` のレスポンスに含まれる `ProdCat`（商品区分コード）フィールドが `StockMaster` モデルに未対応だったため追加
- 対応する `FieldSchema` 定義・`field_count` も更新